### PR TITLE
Helps with tests breaking

### DIFF
--- a/.github/workflows/actions_workflow.yml
+++ b/.github/workflows/actions_workflow.yml
@@ -21,13 +21,8 @@ jobs:
           TMP_COMPOSER_VERSION='2.8.6'
           echo "COMPOSER_VERSION=${TMP_COMPOSER_VERSION}"
           echo "COMPOSER_VERSION=${TMP_COMPOSER_VERSION}" >> $GITHUB_ENV
-          
-          DEPLOYMENT_DIR="`echo $GITHUB_REPOSITORY | awk -F '/' '{printf $2}'`"
-          echo "DEPLOYMENT_DIR=${DEPLOYMENT_DIR}"
-          echo "DEPLOYMENT_DIR=${DEPLOYMENT_DIR}" >> $GITHUB_ENV
 
       - name: Populate composer_auth
-        id: set_composer_auth
         run: |
           cat > /tmp/composer_auth <<EOF
             '{
@@ -42,7 +37,7 @@ jobs:
           echo "$TMP_COMPOSER_AUTH" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
           
-      - name: Setup PHP with composer v2
+      - name: Setup PHP with Composer
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -53,7 +48,6 @@ jobs:
         continue-on-error: true
         with:
           ref: main
-          path: ${{ env.DEPLOYMENT_DIR }}
           fetch-depth: 0
           persist-credentials: true
           set-safe-directory: true
@@ -61,8 +55,6 @@ jobs:
           clean: true
 
       - name: Composer install
-        working-directory: ${{ env.DEPLOYMENT_DIR }}
-        id: composer_install
         run: composer install --ansi --verbose
           
       - name: Runnning Test(s)

--- a/.github/workflows/actions_workflow.yml
+++ b/.github/workflows/actions_workflow.yml
@@ -8,6 +8,7 @@ env:
    DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
    FORCE_COLOR: true
    TERM: xterm-256color
+   PHP_VERSION: '8.4'
 
 jobs:
   build:
@@ -40,7 +41,7 @@ jobs:
       - name: Setup PHP with Composer
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ env.PHP_VERSION }}
           tools: "composer:${{ env.COMPOSER_VERSION }}"
           
       - name: CheckOut Source Code
@@ -54,16 +55,13 @@ jobs:
           submodules: 'recursive'
           clean: true
 
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+
       - name: Composer install
         run: composer install --ansi --verbose
-          
-      - name: Runnning Test(s)
-        working-directory: ${{ env.DEPLOYMENT_DIR }}
-        run: |
-         ./vendor/bin/phpunit --colors tests/ 2>&1 | tee output.log
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          tail -n 1000 output.log >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          
+        
+      - name: Runnning PHPUnit tests
+        uses: php-actions/phpunit@v3
 
           

--- a/cfo-info.php
+++ b/cfo-info.php
@@ -3,4 +3,7 @@ define('GLOBAL_CFO_VERSION', '0.0.8');
 define('GLOBAL_CFO_NAME', 'global-cfo');
 define('GLOBAL_CFO_NAMESPACE', 'GlobalCfo');
 define('GLOBAL_CFO_PLUGIN_FOLDER', __DIR__);
-define('GLOBAL_CFO_PLUGIN_URL', plugin_dir_url(__FILE__));
+
+if (function_exists('plugin_dir_url')) {
+    define('GLOBAL_CFO_PLUGIN_URL', plugin_dir_url(__FILE__));
+}

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
             "Tests\\": "/tests"
         }
     },
+    "scripts": {
+        "run-tests": [
+            "phpunit --colors=always tests/"
+        ]
+    },
     "require": {
         "composer/installers": "~1.0"
     },

--- a/tests/bootstrap.test.php
+++ b/tests/bootstrap.test.php
@@ -1,5 +1,5 @@
 <?php
 
-require __DIR__.'/../vendor/autoload.php';
-require_once GLOBAL_CFO_PLUGIN_FOLDER . '/cfo-info.php';
-require __DIR__.'/../autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
+require_once  __DIR__ . '/../cfo-info.php';
+require __DIR__ . '/../autoload.php';


### PR DESCRIPTION
This PR helps with tests breaking with the introduction of a function only available when plugin is used in a Wordpress context 

![image](https://github.com/user-attachments/assets/725a7867-8760-4478-9844-4f96842a71ee)

In addition this PR addresses a bug with tests silently failing (and not bubbling up the issues correctly)

![image](https://github.com/user-attachments/assets/36264afe-940e-44a7-a51d-bb9e058060ed)

This PR also adds a composer script for dev to run their tests (in a more standardised way) 

```bash
composer run-tests
```
