### PR TITLE
MNB-931: Adding Cache tags feature. Some refactor

### DIFF
--- a/cfo-info.php
+++ b/cfo-info.php
@@ -1,5 +1,5 @@
 <?php
-define('GLOBAL_CFO_VERSION', '0.0.13');
+define('GLOBAL_CFO_VERSION', '1.1.0');
 define('GLOBAL_CFO_NAME', 'global-cfo');
 define('GLOBAL_CFO_NAMESPACE', 'GlobalCfo');
 define('GLOBAL_CFO_PLUGIN_FOLDER', __DIR__);

--- a/dist/admin.css
+++ b/dist/admin.css
@@ -18,6 +18,11 @@
     height: 120px;
     animation: spin 2s linear infinite;
 }
+.global-cfo_tags-row {
+    td[contenteditable] {
+        background-color: white;
+    }
+}
     
 @keyframes spin {
 0% { transform: rotate(0deg); }

--- a/dist/public.js
+++ b/dist/public.js
@@ -10,12 +10,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     let cfoMarkets = document.getElementById('cfo-purge-container')?.children;
-    for (const cfoMarketButton of cfoMarkets) {
-        cfoMarketButton.onclick = function () {
-            if (confirm("Are you sure you want to clear the cache for " + cfoMarketButton.children[0].innerHTML)) {
-                purgeMarket(cfoMarketButton.dataset.cfoMarket);
-            }
-        };
+    if (cfoMarkets != null) {
+        for (const cfoMarketButton of cfoMarkets) {
+            cfoMarketButton.onclick = function () {
+                if (confirm("Are you sure you want to clear the cache for " + cfoMarketButton.children[0].innerHTML)) {
+                    purgeMarket(cfoMarketButton.dataset.cfoMarket);
+                }
+            };
+        }
     }
     
     async function purgeMarket(marketID) {
@@ -50,5 +52,44 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (error) {
             console.error(error);
         }
+    }
+
+    let CPTTagsContainer = document.getElementById('global-cfo_CPTtags');
+    if (CPTTagsContainer != null) {
+        ectractCurrentValue(CPTTagsContainer);
+        let contentEditables = CPTTagsContainer.querySelectorAll('[contenteditable]');
+        contentEditables.forEach(el => {
+            el.addEventListener('input', (e) => {
+                compileCPTTags(CPTTagsContainer);
+            });
+        });
+    }
+    function ectractCurrentValue(CPTTagsContainer) {
+        let CPTTagCurrentValue = document.getElementById('global-cfo_customCPTTags').value;
+        if (CPTTagCurrentValue) {
+            let decodedCurrentValue = JSON.parse(CPTTagCurrentValue);
+            if (decodedCurrentValue) {
+                let CPTRows = CPTTagsContainer.querySelectorAll('tr.global-cfo_tags-row');
+                CPTRows.forEach(CTPRow => {
+                    let tagItems = CTPRow.querySelectorAll('td');
+                    let CPT = tagItems[0].innerHTML;
+                    if (Object.hasOwn(decodedCurrentValue, CPT)) {
+                        let valueForRow = decodedCurrentValue[CPT];
+                        if (valueForRow) {
+                            tagItems[1].innerHTML = valueForRow;
+                        }
+                    }
+                });
+            }
+        }
+    }
+    function compileCPTTags(CPTTagsContainer) {
+        let CPTRows = CPTTagsContainer.querySelectorAll('tr.global-cfo_tags-row');
+        let CPTTags = {};
+        CPTRows.forEach(CTPRow => {
+            let tagItems = CTPRow.querySelectorAll('td');
+            CPTTags[tagItems[0].innerHTML] = tagItems[1].innerHTML;
+        });
+        document.getElementById('global-cfo_customCPTTags').value = JSON.stringify(CPTTags);
     }
 });

--- a/global-cfo.php
+++ b/global-cfo.php
@@ -18,7 +18,7 @@ namespace GlobalCfo;
  * Plugin Name:       Global CFO
  * Plugin URI:        https://github.com/TotalOnion/cloudflareonion
  * Description:       Cloudflare cache handling plugin
- * Version:           0.0.13
+ * Version:           1.1.0
  * Author:            Johann Biteghe
  * Author URI:        https://totalonion.com
  * License:           GPL-2.0+

--- a/src/Controllers/Admin/CacheClearancePage.php
+++ b/src/Controllers/Admin/CacheClearancePage.php
@@ -123,7 +123,7 @@ class CacheClearancePage extends AbstractController
                     'warning'
                 );
 
-                $this->cfoManager->registerSavedItem($url);
+                $this->cfoManager->registerSavedItemURL($url);
             }
         }
 

--- a/src/Controllers/Admin/CacheTags.php
+++ b/src/Controllers/Admin/CacheTags.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace GlobalCfo\Controllers\Admin;
+
+use GlobalCfo\Controllers\AbstractController;
+
+class CacheTags extends AbstractController
+{
+
+    public function __construct()
+    {
+    }
+
+    public function getPurgeBody($postID): string
+    {
+        $tags = $this->getTagsToPurge($postID);
+        $body = json_encode([
+            'tags' => $tags
+        ]);
+        return $body;
+    }
+
+    public function printCacheTagsHeader(): void
+    {
+        $postID = get_the_ID();
+        $cacheTags = $this->getTagsToPrint($postID);
+        $tagsString = implode(',', $cacheTags);
+        header('Cache-Tag: ' . $tagsString);
+    }
+
+    private function getTagsToPrint($postID): array {
+        $tags = [];
+        $tags[] = $this->getIDTag($postID);
+        return $tags;
+    }
+
+    private function getTagsToPurge($postID): array {
+        $tags = [];
+        $tags[] = $this->getIDTag($postID);
+        $cptTag = $this->getCptTag($postID);
+        if ($cptTag) {
+            $tags[] = $this->getCptTag($postID);
+        }
+        return $tags;
+    }
+
+    private function getIDTag($postID): string {
+        return 'cfo-' . $postID;
+    }
+
+    private function getCptTag($postID): string {
+        $cptTag = '';
+        $postType = get_post_type($postID);
+        $cptTagsEncoded = get_option(GLOBAL_CFO_NAME.'_customCPTTags');
+        if ($cptTagsEncoded) {
+            $cptTags = json_decode($cptTagsEncoded);
+            if ($postType && is_object($cptTags) && property_exists($cptTags, $postType)) {
+                $cptTag = $cptTags->{$postType};
+            }
+        }
+        return $cptTag;
+    }
+}

--- a/src/Controllers/Admin/CacheTagsPage.php
+++ b/src/Controllers/Admin/CacheTagsPage.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace GlobalCfo\Controllers\Admin;
+
+use GlobalCfo\Controllers\AbstractController;
+
+class CacheTagsPage extends AbstractController
+{
+    public function registerPage()
+    {
+        // reference https://developer.wordpress.org/reference/functions/add_options_page/
+        add_options_page(
+            'CFO Cache Tags Settings',                     // page title
+            'CFO Cache Tags Settings',                     // menu title
+            'manage_options',                   // capability required to access / see it
+            GLOBAL_CFO_NAME.'_cache-tags-page', // slug (needs to be unique)
+            [$this, 'renderPage']               // callable function to render the page
+        );
+    }
+
+    private function registerCacheTagsFields()
+    {
+        add_settings_section(
+            GLOBAL_CFO_NAME.'_options_section_tags',
+            'Cache Tags Settings',
+            [$this, 'renderSectionIntro'],
+            GLOBAL_CFO_NAME.'_cache-tags-page'
+        );
+
+        add_option(GLOBAL_CFO_NAME.'_enableCacheTags');
+        register_setting(
+            GLOBAL_CFO_NAME.'_tags_options',
+            GLOBAL_CFO_NAME.'_enableCacheTags',
+            [
+                'type' => 'number',
+                'description' => 'Whether or not to enable Cache Tags based purging',
+                'sanitize_callback' => 'sanitize_text_field',
+                'show_in_rest' => true,
+                'default' => ''
+            ]
+        );
+        add_settings_field(
+            GLOBAL_CFO_NAME.'_enableCacheTags',
+            'Enable Tags based purging',
+            [$this, 'renderField'],
+            GLOBAL_CFO_NAME.'_cache-tags-page',
+            GLOBAL_CFO_NAME.'_options_section_tags',
+            [
+                'id' => GLOBAL_CFO_NAME.'_enableCacheTags',
+                'type' => 'checkbox'
+            ]
+        );
+
+        add_option(GLOBAL_CFO_NAME.'_customCPTTags');
+        register_setting(
+            GLOBAL_CFO_NAME.'_tags_options',
+            GLOBAL_CFO_NAME.'_customCPTTags',
+            [
+                'type' => 'text',
+                'description' => 'Custom tag to purge when a specific post type is saved',
+                'sanitize_callback' => 'sanitize_text_field',
+                'show_in_rest' => true,
+                'default' => ''
+            ]
+        );
+        add_settings_field(
+            GLOBAL_CFO_NAME.'_customCPTTags',
+            'Custom tag to purge per post type',
+            [$this, 'renderField'],
+            GLOBAL_CFO_NAME.'_cache-tags-page',
+            GLOBAL_CFO_NAME.'_options_section_tags',
+            [
+                'id' => GLOBAL_CFO_NAME.'_customCPTTags',
+                'type' => 'CPTTable',
+                'CPTs' => get_option(GLOBAL_CFO_NAME.'_purgePostTypes', '')
+            ]
+        );
+    }
+
+    public function registerSettings()
+    {
+        $this->registerCacheTagsFields();
+    }
+
+    public function renderSectionIntro()
+    {
+        echo __('', GLOBAL_CFO_NAME);
+    }
+
+    public function renderField($fieldParameters)
+    {
+        echo $this->render(
+            'forms:fields/'.$fieldParameters['type'].'.php',
+            [
+                'id' => $fieldParameters['id'],
+                'name' => $fieldParameters['id'],
+                'currentValue' => get_option($fieldParameters['id']) ?? '',
+                'cssClass' => $fieldParameters['cssClass'] ?? '',
+                'choices' => $fieldParameters['choices'] ?? '',
+                'CPTs' => $fieldParameters['CPTs'] ?? ''
+            ]
+        );
+    }
+
+    public function renderPage()
+    {
+        echo $this->render('forms:settingsPage.php');
+    }
+}

--- a/src/Controllers/Admin/CacheTagsPage.php
+++ b/src/Controllers/Admin/CacheTagsPage.php
@@ -65,7 +65,7 @@ class CacheTagsPage extends AbstractController
         );
         add_settings_field(
             GLOBAL_CFO_NAME.'_customCPTTags',
-            'Custom tag to purge per post type',
+            'Tags to purge by PostType',
             [$this, 'renderField'],
             GLOBAL_CFO_NAME.'_cache-tags-page',
             GLOBAL_CFO_NAME.'_options_section_tags',

--- a/src/Controllers/Admin/CfoManager.php
+++ b/src/Controllers/Admin/CfoManager.php
@@ -3,24 +3,38 @@ namespace GlobalCfo\Controllers\Admin;
 
 use GlobalCfo\Controllers\AbstractController;
 use GlobalCfo\Controllers\Admin\Logger;
+use GlobalCfo\Controllers\Admin\CacheTags;
 
 class CfoManager extends AbstractController
 {
     private Logger $logger;
+    private CacheTags $cacheTags;
 
     public function __construct($pluginName, $version)
     {
         $this->logger = new Logger($version, $pluginName);
+        $this->cacheTags = new CacheTags($version, $pluginName);
         parent::__construct($pluginName, $version);
     }
 
-    public function registerSavedItem($url)
+    public function registerSavedItemURL($url)
     {
         $this->sendPurgeRequest($this->getPurgeBodyUrl($url));
 
         if ($this->getTrailingSlashOption()) {
             $this->sendPurgeRequest($this->getPurgeBodyUrl(rtrim($url, '/')));
         }
+    }
+
+    public function registerSavedItemCacheTags($postID)
+    {
+        $purgeBody = $this->cacheTags->getPurgeBody($postID);
+        $this->sendPurgeRequest($purgeBody);
+    }
+
+    public function printCacheTagsHeader()
+    {
+        $this->cacheTags->printCacheTagsHeader();
     }
 
     public function registerSavedPost($postID)
@@ -33,12 +47,18 @@ class CfoManager extends AbstractController
         $postTypesToPurge = $this->getPostTypesOption();
 
         // Skipping purge for post types not in the list
-        if (!in_array($postType, $postTypesToPurge)) {
+        if ((empty($postTypesToPurge)) || (!empty($postTypesToPurge) && !in_array($postType, $postTypesToPurge))) {
             return;
         }
 
-        $postUrl = get_permalink($postID);
-        $this->registerSavedItem($postUrl);
+        $cacheTagsEnabled = $this->getCacheTagsEnabled();
+
+        if ( $cacheTagsEnabled ) {
+            $this->registerSavedItemCacheTags($postID);
+        } else {
+            $postUrl = get_permalink($postID);
+            $this->registerSavedItemURL($postUrl);
+        }
     }
 
     public function purgeMarket($marketId)
@@ -155,5 +175,10 @@ class CfoManager extends AbstractController
     protected function getDomainReplace(): string
     {
         return get_option(GLOBAL_CFO_NAME.'_replace_domain');
+    }
+
+    private function getCacheTagsEnabled(): string
+    {
+        return get_option(GLOBAL_CFO_NAME.'_enableCacheTags');
     }
 }

--- a/src/GlobalCfo.php
+++ b/src/GlobalCfo.php
@@ -98,14 +98,20 @@ class GlobalCfo {
         $this->loader->addAction('admin_menu', $settingsPage, 'registerPage');
         $this->loader->addAction('admin_init', $settingsPage, 'registerSettings');
         
-        // Add the cache page
+        // Add the cache clearance page
         $cacheClearancePage = new Admin\CacheClearancePage($this->getPluginName(), $this->getVersion());
         $this->loader->addAction('admin_menu', $cacheClearancePage, 'registerPage');
         $this->loader->addAction('admin_init', $cacheClearancePage, 'registerSettings');
 
+        // Add the cache tags page
+        $cacheTagsPage = new Admin\CacheTagsPage($this->getPluginName(), $this->getVersion());
+        $this->loader->addAction('admin_menu', $cacheTagsPage, 'registerPage');
+        $this->loader->addAction('admin_init', $cacheTagsPage, 'registerSettings');
+
         // Add the forms post type etc
         $cfoManager = new Admin\CfoManager($this->getPluginName(), $this->getVersion());
         $this->loader->addAction('save_post', $cfoManager, 'registerSavedPost');
+        $this->loader->addAction('wp_head', $cfoManager, 'printCacheTagsHeader');
 
         // Add the endpoints
         $API = new Admin\CfoAPI($this->getPluginName(), $this->getVersion(), $cfoManager);

--- a/src/Resources/views/forms/fields/CPTTable.php
+++ b/src/Resources/views/forms/fields/CPTTable.php
@@ -1,0 +1,23 @@
+<table id="global-cfo_CPTtags">
+    <thead><tr class="global-cfo_tags-head">
+        <th>Post Type</th>
+        <th>Tag to Clear</th>
+    </tr></thead>
+    <?php
+        if ($CPTs) {
+            foreach ($CPTs as $CPT) {
+                if (is_array($currentValue) && in_array($CPT, $currentValue)) {
+                    $currentTag = $currentValue[$CPT];
+                } else {
+                    $currentTag = '';
+                }?>
+                <tr class="global-cfo_tags-row">
+                    <td><?php echo $CPT; ?></td>
+                    <td contenteditable><?php echo $currentTag; ?></td>
+                </tr>
+            <?php }
+        } ?>
+<input hidden type="text" id="<?php echo $id; ?>" name="<?php echo $name; ?>" value="<?php echo esc_attr($currentValue); ?>" />
+</table>
+
+

--- a/src/Resources/views/forms/settingsPage.php
+++ b/src/Resources/views/forms/settingsPage.php
@@ -14,6 +14,10 @@ $page = isset($_GET['page']) ? $_GET['page'] : GLOBAL_CFO_NAME . 'settings-page'
             class="nav-tab <?php echo $page == GLOBAL_CFO_NAME . '_cache-clearance-page' ? 'nav-tab-active' : ''; ?>">
             Clear Cache
         </a>
+        <a href="<?php echo admin_url('admin.php?page=' . GLOBAL_CFO_NAME . '_cache-tags-page'); ?>"
+            class="nav-tab <?php echo $page == GLOBAL_CFO_NAME . '_cache-tags-page' ? 'nav-tab-active' : ''; ?>">
+            Cache Tags
+        </a>
     </h2>
 
 </div>
@@ -32,7 +36,7 @@ $page = isset($_GET['page']) ? $_GET['page'] : GLOBAL_CFO_NAME . 'settings-page'
         </form>
 
     <?php
-    else:
+    elseif ($page == GLOBAL_CFO_NAME . '_cache-clearance-page'):
     ?>
         <h1>Cache Clearance</h1>
         <form method="post" action="options.php">
@@ -40,6 +44,17 @@ $page = isset($_GET['page']) ? $_GET['page'] : GLOBAL_CFO_NAME . 'settings-page'
             settings_fields(GLOBAL_CFO_NAME . '_clearance');
             do_settings_sections(GLOBAL_CFO_NAME . '_cache-clearance-page');
             submit_button('Validate Path(s)');
+            ?>
+        </form>
+    <?php
+    elseif ($page == GLOBAL_CFO_NAME . '_cache-tags-page'):
+    ?>
+        <h1>Cache Tags</h1>
+        <form method="post" action="options.php">
+            <?php
+            settings_fields(GLOBAL_CFO_NAME . '_tags_options');
+            do_settings_sections(GLOBAL_CFO_NAME . '_cache-tags-page');
+            submit_button();
             ?>
         </form>
 


### PR DESCRIPTION
Adding cache tag features V1 : 


When saving a post : 
Sends a purge request to Cloudflare with :
Cache tags comprised of ID of the page `cfo-12345`
Custom tag that can be set in the admin
<img width="2028" height="128" alt="image" src="https://github.com/user-attachments/assets/24071146-b35e-42b2-8e62-522d41c05961" />

When generating HTML:
Adds a header that will be interpreted by Cloudflare:
comprised of ID of the page
<img width="298" height="50" alt="image" src="https://github.com/user-attachments/assets/3de6e8ff-72a1-41f4-ab28-e5a11edb76ca" />


Admin page:
Can enable purging by cache tags INSTEAD of by URL.
Can set a Custom Tag to clear every time a post from a certain Post Type is saved.
<img width="1324" height="1134" alt="image" src="https://github.com/user-attachments/assets/13cf0154-91a6-4531-bb73-0eae7813089d" />


Implementation notes :

Need to send a header like `post-archive`  on archive pages

TODO:
Some admin cleanup, styling, UX etc